### PR TITLE
prod/wings: Fix procstat for web

### DIFF
--- a/wings/ops.yml
+++ b/wings/ops.yml
@@ -17,7 +17,22 @@
         password: concourse
       inputs:
         procstat:
-          exe: atc
+          exe: web
+
+- type: replace
+  path: /instance_groups/name=worker/jobs/-
+  value:
+    name: telegraf-agent
+    release: telegraf-agent
+    properties:
+      influxdb:
+        url: http://10.2.0.2:8086
+        database: wings
+        username: concourse
+        password: concourse
+      inputs:
+        procstat:
+          exe: worker
 
 - type: replace
   path: /instance_groups/-


### PR DESCRIPTION
- After 5.0 `telegraf` should use `web` instead of `atc` to get web PID.
- Also, Adding procstat for workers to fix concourse/concourse#2697
