### PR TITLE
Disable parallel queries due to postgres bug

### DIFF
--- a/prod/ops.yml
+++ b/prod/ops.yml
@@ -27,3 +27,7 @@
       inputs:
         procstat:
           exe: concourse
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/additional_config?/max_parallel_workers_per_gather
+  value: 0


### PR DESCRIPTION
For context:
- https://www.postgresql.org/message-id/15585-324ff6a93a18da46@postgresql.org
- https://www.postgresql.org/message-id/flat/20190207014719.GJ29720@telsasoft.com

postgres 11.2 has a problem with parallel queries.