### PR TITLE
Revert "disable parallel queries due to postgres bug"

### DIFF
--- a/prod/ops.yml
+++ b/prod/ops.yml
@@ -27,7 +27,3 @@
       inputs:
         procstat:
           exe: concourse
-
-- type: replace
-  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/additional_config?/max_parallel_workers_per_gather
-  value: 0


### PR DESCRIPTION
This reverts commit de257845fe317551de384ceadd635f52edafe423 
as we already got to PostgreSQL 11.3 which has the fix for the `dsa_*`
problem.