### PR TITLE
Modify ops file for PostgreSQL performance tuning

### DIFF
--- a/prod/ops.yml
+++ b/prod/ops.yml
@@ -36,10 +36,10 @@
 - type: replace
   path: /instance_groups/name=db/jobs/name=postgres/properties/databases/additional_config?
   value:
-    shared_buffers: 2GB
-    effective_cache_size: 7GB
+    shared_buffers: 262144
+    effective_cache_size: 917504
     checkpoint_completion_target: 0.9
     default_statistics_target: 1000
-    work_mem: 8MB
-    maintenance_work_mem: 128MB
-    random_page_cost: 3.0
+    work_mem: 8192
+    maintenance_work_mem: 131072
+    random_page_cost: 3

--- a/prod/ops.yml
+++ b/prod/ops.yml
@@ -27,3 +27,19 @@
       inputs:
         procstat:
           exe: concourse
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/max_connections?
+  value: 220
+
+
+- type: replace
+  path: /instance_groups/name=db/jobs/name=postgres/properties/databases/additional_config?
+  value:
+    shared_buffers: 2GB
+    effective_cache_size: 7GB
+    checkpoint_completion_target: 0.9
+    default_statistics_target: 1000
+    work_mem: 8MB
+    maintenance_work_mem: 128MB
+    random_page_cost: 3.0


### PR DESCRIPTION
Hi,

Here @pivotal-bin-ju and I have applied the performance tunings that were suggested in the internal spreadsheet to verify if we can get some better utilization out of our deployed PostgreSQL instance.

We verified that having the ops file applied against the [`concourse-bosh-deployment/cluster/concourse.yml`][manifest] manifest it renders properly.

Thanks!

[manifest]: https://github.com/concourse/concourse-bosh-deployment/blob/c945aedccaa15f22c04b1eb339597541cdc6437f/cluster/concourse.yml
