### PR TITLE
Add ops-file for external worker on PKS

### DIFF
--- a/pks-worker/ops.yml
+++ b/pks-worker/ops.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=worker/jobs/name=worker/properties/tags?
+  value: [pks]


### PR DESCRIPTION
When prod updates automatically through CI we want to ensure that we also update the external worker that is managed by our vsphere bosh director. This ops-file will be used by a job in CI to redeploy this external worker.

Related PR's which uses the tag this PR mentions: 
- https://github.com/concourse/ci/pull/58
- https://github.com/concourse/ci/pull/57

For more details read concourse/ci#40

CC @cirocosta 