### PR TITLE
specify input params for disk and net telegraf metrics

### DIFF
--- a/prod/ops.yml
+++ b/prod/ops.yml
@@ -27,6 +27,10 @@
       inputs:
         procstat:
           exe: concourse
+        disk:
+          mount_points: ["/var/vcap/data"]
+        net:
+          interfaces: ["eth0"]
 
 - type: replace
   path: /instance_groups/name=untrusted-worker/jobs/name=worker/properties/baggageclaim?/driver?


### PR DESCRIPTION
Signed-off-by: Divya Dadlani <ddadlani@pivotal.io>
Co-authored-by: Bin Ju <bju@pivotal.io>

must wait on https://github.com/vito/telegraf-agent-boshrelease/pull/3 to be merged in before this PR can be merged.

fixes https://github.com/pivotal/concourse-ops/issues/95